### PR TITLE
fix: 만다라트 수정이 안되는 현상 수정

### DIFF
--- a/src/main/java/com/green1st/mandalartWeb/mandalart/MandalartService.java
+++ b/src/main/java/com/green1st/mandalartWeb/mandalart/MandalartService.java
@@ -131,14 +131,18 @@ public class MandalartService {
 
     @Transactional
     public int patchMandalart(MandalartPostReq p) {
-        MandalartGetRes parentMand = mapper.selMandalartByMandalartId(p.getParentId());
-
         if (p.getStartDate() != null && p.getFinishDate() != null && !p.getStartDate().isBefore(p.getFinishDate())) {
             throw new IllegalArgumentException("시작일은 종료일보다 이전이어야 합니다.");
         }
 
+        MandalartGetRes parentMand = mapper.selMandalartByMandalartId(p.getParentId());
+
         if(parentMand != null) {
-            if(parentMand.getFinishDate().equals(p.getStartDate()) || parentMand.getStartDate().isBefore(p.getStartDate()) || parentMand.getFinishDate().isAfter(p.getFinishDate())) {
+            if(parentMand.getStartDate() == null || parentMand.getFinishDate() == null) {
+                throw new IllegalArgumentException("상위 목표의 기간이 설정 되지 않았습니다.");
+            }
+
+            if(parentMand.getFinishDate().equals(p.getStartDate()) || p.getStartDate().isBefore(parentMand.getStartDate()) || p.getFinishDate().isAfter(parentMand.getFinishDate())) {
                 throw new IllegalArgumentException("상위 목표의 기간을 벗어 납니다.");
             }
 

--- a/src/main/resources/mappers/mandalart/Mandalart.xml
+++ b/src/main/resources/mappers/mandalart/Mandalart.xml
@@ -48,6 +48,18 @@
 
     <update id="patchMandalart">
         UPDATE mandalart
+        <set>
+            <if test="title != null">title = #{title}</if>
+            <if test="contents != null">, contents = #{contents}</if>
+            <if test="completedFg != null">, completed_fg = #{completedFg}</if>
+            <if test="startDate != null">, start_date = #{startDate}</if>
+            <if test="finishDate != null">, finish_date = #{finishDate}</if>
+        </set>
+        WHERE mandalart_id = #{mandalartId}
+    </update>
+
+    <update id="patchMandalartBefore">
+        UPDATE mandalart
         SET
         title = IF(title IS NOT NULL, title, NULL),
         contents = IF(contents IS NOT NULL, contents, NULL),


### PR DESCRIPTION
- 만다라트 수정 성공이라고 메세지가 떳지만 실제로 수정되지 않음(Mapper XML파일 수정 patch 쿼리문 다시 작성함.)
- 부모일자 검사가 반대로 되어있어서 로직 변경